### PR TITLE
대기 순번 알림 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     image: redis/redis-stack
     container_name: redis-stack-compose
     restart: always
-    environment:
-      REDIS_ARGS: "--requirepass systempass"
+    command: ["redis-server", "--requirepass", "systempass", "--notify-keyspace-events", "KEA"]
     ports:
       - 6379:6379
       - 8001:8001

--- a/src/main/java/com/qring/queue/application/v2/message/kafka/KafkaMessageProducerV2.java
+++ b/src/main/java/com/qring/queue/application/v2/message/kafka/KafkaMessageProducerV2.java
@@ -1,0 +1,6 @@
+package com.qring.queue.application.v2.message.kafka;
+
+public interface KafkaMessageProducerV2 {
+
+    void publishQueueAlarmEvent(Long reservationId);
+}

--- a/src/main/java/com/qring/queue/application/v2/message/redis/RedisKeyspaceListener.java
+++ b/src/main/java/com/qring/queue/application/v2/message/redis/RedisKeyspaceListener.java
@@ -1,13 +1,11 @@
 package com.qring.queue.application.v2.message.redis;
 
+import com.qring.queue.application.v2.message.kafka.KafkaMessageProducerV2;
 import com.qring.queue.application.v2.service.QueueServiceV2;
-import com.qring.queue.infrastructure.messaging.dto.QueueAlarmEventDTO;
-import com.qring.queue.infrastructure.messaging.redis.RedisMessagePublisherImplV2;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -18,8 +16,8 @@ import java.util.List;
 public class RedisKeyspaceListener implements MessageListener {
 
     private final QueueServiceV2 queueService;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
-    private final RedisMessagePublisherImplV2 redisMessagePublisherV2;
+    private final KafkaMessageProducerV2 kafkaMessageProducerV2;
+    private final RedisMessagePublisherV2 redisMessagePublisherV2;
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
@@ -67,8 +65,7 @@ public class RedisKeyspaceListener implements MessageListener {
     }
 
     private void sendQueueAlarmEvent(Long reservationId) {
-        QueueAlarmEventDTO event = new QueueAlarmEventDTO(reservationId);
-        kafkaTemplate.send("queue-alarm-event-topic", event);
+        kafkaMessageProducerV2.publishQueueAlarmEvent(reservationId);
         log.info("Kafka 메시지 발행: {}", reservationId);
     }
 

--- a/src/main/java/com/qring/queue/application/v2/message/redis/RedisKeyspaceListener.java
+++ b/src/main/java/com/qring/queue/application/v2/message/redis/RedisKeyspaceListener.java
@@ -1,0 +1,79 @@
+package com.qring.queue.application.v2.message.redis;
+
+import com.qring.queue.application.v2.service.QueueServiceV2;
+import com.qring.queue.infrastructure.messaging.dto.QueueAlarmEventDTO;
+import com.qring.queue.infrastructure.messaging.redis.RedisMessagePublisherImplV2;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisKeyspaceListener implements MessageListener {
+
+    private final QueueServiceV2 queueService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final RedisMessagePublisherImplV2 redisMessagePublisherV2;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String key = new String(message.getBody());
+        String event = new String(pattern);
+
+        log.info("Redis 대기열 변동 이벤트 감지: key={}, event={}", key, event);
+
+        // Key에서 식당 ID 추출
+        Long restaurantId = extractRestaurantIdFromKey(key);
+
+        switch (event) {
+            case "__keyevent@*__:zadd" -> handleZAddEvent(restaurantId);
+            case "__keyevent@*__:zrem" -> handleZRemEvent(restaurantId);
+            default -> log.warn("Redis 알 수 없는 이벤트 감지: {}", event);
+        }
+    }
+
+    private void handleZAddEvent(Long restaurantId) {
+        processFifthReservationEvent(restaurantId);
+    }
+
+    private void handleZRemEvent(Long restaurantId) {
+        processFifthReservationEvent(restaurantId);
+    }
+
+    private void processFifthReservationEvent(Long restaurantId) {
+        List<Long> waitingList = queueService.getWaitingListBy(restaurantId);
+        if (waitingList.size() >= 5) {
+            Long fifthReservationId = waitingList.get(4); // 5번째 예약 ID
+            // Redis에서 마지막 발송된 ID 확인
+            String lastSentId = redisMessagePublisherV2.getLastSentId(restaurantId);
+
+            // 5번째 ID가 이전에 발송된 ID와 다를 경우에만 이벤트 발송
+            if (!fifthReservationId.toString().equals(lastSentId)) {
+                sendQueueAlarmEvent(fifthReservationId); // Kafka 이벤트 발송
+
+                // Redis에 발송된 ID 저장
+                redisMessagePublisherV2.saveLastSentId(restaurantId, String.valueOf(fifthReservationId));
+                log.info("Kafka 5번째 순번 예약 ID 이벤트 발송: 식당 ID = {}, 예약 ID = {}", restaurantId, fifthReservationId);
+            } else {
+                log.info("Redis 중복 이벤트 방지: 식당 ID = {}, 예약 ID = {}", restaurantId, fifthReservationId);
+            }
+        }
+    }
+
+    private void sendQueueAlarmEvent(Long reservationId) {
+        QueueAlarmEventDTO event = new QueueAlarmEventDTO(reservationId);
+        kafkaTemplate.send("queue-alarm-event-topic", event);
+        log.info("Kafka 메시지 발행: {}", reservationId);
+    }
+
+    private Long extractRestaurantIdFromKey(String key) {
+        // Key에서 숫자 ID를 추출 (예: "waiting_list123" -> 123)
+        return Long.parseLong(key.replaceAll("\\D+", ""));
+    }
+}

--- a/src/main/java/com/qring/queue/application/v2/message/redis/RedisMessagePublisherV2.java
+++ b/src/main/java/com/qring/queue/application/v2/message/redis/RedisMessagePublisherV2.java
@@ -17,4 +17,5 @@ public interface RedisMessagePublisherV2 {
     String getLastSentId(Long restaurantId);
 
     void saveLastSentId(Long restaurantId, String reservationId);
+
 }

--- a/src/main/java/com/qring/queue/application/v2/message/redis/RedisMessagePublisherV2.java
+++ b/src/main/java/com/qring/queue/application/v2/message/redis/RedisMessagePublisherV2.java
@@ -2,6 +2,8 @@ package com.qring.queue.application.v2.message.redis;
 
 import com.qring.queue.application.v2.res.QueueGetResDTOV2;
 
+import java.util.Set;
+
 public interface RedisMessagePublisherV2 {
 
     void addWaitingListByRestaurantIdAndReservationId(Long restaurantId, Long reservationId);
@@ -9,4 +11,10 @@ public interface RedisMessagePublisherV2 {
     QueueGetResDTOV2 getQueueInfoByRestaurantIdAndReservationId(Long restaurantId, Long reservationId);
 
     void removeQueueByRestaurantIdAndReservationId(Long restaurantId, Long reservationId);
+
+    Set<Object> getFromWaitingList(String key);
+
+    String getLastSentId(Long restaurantId);
+
+    void saveLastSentId(Long restaurantId, String reservationId);
 }

--- a/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
+++ b/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
@@ -31,7 +31,7 @@ public class QueueServiceV2 {
     }
 
     // 대기열에서 제거
-    public void removeBy(Long restaurantId, Long reservationId) {
+    public void deleteBy(Long restaurantId, Long reservationId) {
 
         redisMessagePublisherV2.removeQueueByRestaurantIdAndReservationId(restaurantId, reservationId);
     }

--- a/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
+++ b/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.*;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j(topic = "QueueServiceV2 Log")
@@ -34,5 +36,21 @@ public class QueueServiceV2 {
     public void deleteBy(Long restaurantId, Long reservationId) {
 
         redisMessagePublisherV2.removeQueueByRestaurantIdAndReservationId(restaurantId, reservationId);
+    }
+
+    // ============== 대기 순번 알림 발송 관련 ================
+    // 식당별 대기열 리스트 조회
+    public List<Long> getWaitingListBy(Long restaurantId) {
+        String key = "waiting_list" + restaurantId; // Redis Key 생성
+        Set<Object> waitingList = redisMessagePublisherV2.getFromWaitingList(key); // Redis에서 모든 데이터 조회
+        if (waitingList.isEmpty()) {
+            log.info("대기열이 비어있습니다.");
+            return Collections.emptyList();
+        }
+
+        return waitingList.stream()
+                .map(obj -> Long.valueOf(obj.toString())) // Object -> Long 변환
+                .sorted() // 순서를 보장
+                .toList();
     }
 }

--- a/src/main/java/com/qring/queue/infrastructure/config/KafkaProducerConfig.java
+++ b/src/main/java/com/qring/queue/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,35 @@
+package com.qring.queue.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public NewTopic queueAlarmEventTopic() {
+        return new NewTopic("queue-alarm-event-topic", 1, (short) 1);
+    }
+}

--- a/src/main/java/com/qring/queue/infrastructure/config/RedisListenerConfig.java
+++ b/src/main/java/com/qring/queue/infrastructure/config/RedisListenerConfig.java
@@ -1,0 +1,33 @@
+package com.qring.queue.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.Topic;
+
+@Configuration
+public class RedisListenerConfig {
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    public RedisListenerConfig(RedisConnectionFactory redisConnectionFactory) {
+        this.redisConnectionFactory = redisConnectionFactory;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(MessageListener redisKeyspaceListener) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+
+        // Keyspace Notifications 채널 구독: zadd (추가) 및 zrem (삭제) 이벤트
+        Topic zaddTopic = new PatternTopic("__keyevent@*__:zadd");
+        Topic zremTopic = new PatternTopic("__keyevent@*__:zrem");
+
+        container.addMessageListener(redisKeyspaceListener, zaddTopic);
+        container.addMessageListener(redisKeyspaceListener, zremTopic);
+
+        return container;
+    }
+}

--- a/src/main/java/com/qring/queue/infrastructure/docs/QueueControllerSwagger.java
+++ b/src/main/java/com/qring/queue/infrastructure/docs/QueueControllerSwagger.java
@@ -33,6 +33,6 @@ public interface QueueControllerSwagger {
             @ApiResponse(responseCode = "400", description = "대기 취소 실패", content = @Content(schema = @Schema(implementation = ResDTO.class))),
     })
     @DeleteMapping
-    ResponseEntity<ResDTO<Object>> removeBy(@RequestParam Long restaurantId,
+    ResponseEntity<ResDTO<Object>> deleteBy(@RequestParam Long restaurantId,
                                             @RequestParam Long reservationId);
 }

--- a/src/main/java/com/qring/queue/infrastructure/messaging/dto/QueueAlarmEventDTO.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/dto/QueueAlarmEventDTO.java
@@ -1,0 +1,10 @@
+package com.qring.queue.infrastructure.messaging.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QueueAlarmEventDTO {
+    private Long reservationId;
+}

--- a/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageProducerImplV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageProducerImplV2.java
@@ -1,0 +1,20 @@
+package com.qring.queue.infrastructure.messaging.kafka;
+
+import com.qring.queue.application.v2.message.kafka.KafkaMessageProducerV2;
+import com.qring.queue.infrastructure.messaging.dto.QueueAlarmEventDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducerImplV2 implements KafkaMessageProducerV2 {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void publishQueueAlarmEvent(Long reservationId) {
+
+        QueueAlarmEventDTO event = new QueueAlarmEventDTO(reservationId);
+        kafkaTemplate.send("queue-alarm-event-topic", event);
+    }
+}

--- a/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
@@ -8,7 +8,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Optional;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
+import java.util.*;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +18,7 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
     private final RedisTemplate<String, Object> redisTemplate;
 
     private static final String WAITING_LIST_KEY_PREFIX = "waiting_list";
+    private static final String LAST_SENT_KEY_PREFIX = "last_sent_event:";
 
     // 대기열에 등록
     public void addWaitingListByRestaurantIdAndReservationId(Long restaurantId, Long reservationId) {
@@ -42,11 +43,13 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
                 .map(Long::intValue)
                 .orElseThrow(() -> new IllegalArgumentException("대기열에 존재하지 않거나 이미 삭제되었습니다."));
 
+        // ========== 추후 미루기 기능에 사용될 것 같아 삭제하지 않고 주석 처리 ===========
 //        // 대기열에 사용자가 없을 경우 등록
 //        if (rank == -1) {
 //            addWaitingListByRestaurantIdAndReservationId(restaurantId, reservationId);
 //            rank = getRankByKeyAndValue(zSetOps, key, String.valueOf(reservationId));
 //        }
+        // ===================================================================
 
         // 총 대기 인원 조회
         int totalWaitingCount = Optional.ofNullable(zSetOps.zCard(key))
@@ -72,4 +75,23 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
 
         zSetOps.remove(key, String.valueOf(reservationId));
     }
+
+    // ============ 대기 순번 알림 발송 관련 ================
+    // 대기열 정보 전체 가져오기
+    public Set<Object> getFromWaitingList(String key) {
+        ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
+        return zSetOps.range(key, 0, -1); // ZSet의 모든 데이터를 가져옴
+    }
+    // 마지막 발송 ID 조회
+    public String getLastSentId(Long restaurantId) {
+        String key = LAST_SENT_KEY_PREFIX + restaurantId;
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    // 마지막 발송 ID 저장
+    public void saveLastSentId(Long restaurantId, String reservationId) {
+        String key = LAST_SENT_KEY_PREFIX + restaurantId;
+        redisTemplate.opsForValue().set(key, reservationId);
+    }
+
 }

--- a/src/main/java/com/qring/queue/presentation/v2/controller/QueueControllerV2.java
+++ b/src/main/java/com/qring/queue/presentation/v2/controller/QueueControllerV2.java
@@ -31,10 +31,10 @@ public class QueueControllerV2 implements QueueControllerSwagger {
     }
 
     @PostMapping
-    public ResponseEntity<ResDTO<Object>> removeBy(@RequestParam Long restaurantId,
+    public ResponseEntity<ResDTO<Object>> deleteBy(@RequestParam Long restaurantId,
                                                    @RequestParam Long reservationId) {
 
-        queueServiceV2.removeBy(restaurantId, reservationId);
+        queueServiceV2.deleteBy(restaurantId, reservationId);
 
         return new ResponseEntity<>(
                 ResDTO.builder()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,9 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       properties:
         spring.json.trusted.packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 eureka:
   client:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #12 

## 📝 Description

- Redis의 Keyspace Notifications 채널을 구독하여 대기가 추가 or 삭제 될때마다 대기열 변동 이벤트를 감지합니다.
- 대기열 변동 이벤트를 감지할때마다 해당 대기열의 5번째 순번인 예약ID를 예약 서비스에 이벤트로 발행합니다.
- 같은 예약ID로 또다시 이벤트가 발행될 경우를 대비하여 중복 이벤트 감지 기능을 추가하였습니다.

## 💬 To Reivewers

- 생각해보니 대기열에 대기가 추가되었을 때는 감지할 필요가 없는 것 같기도합니다..!
