### PR TITLE
대기 서비스 SAGA 패턴 적용

### DIFF
--- a/src/main/java/com/qring/queue/application/v2/message/kafka/KafkaMessageProducerV2.java
+++ b/src/main/java/com/qring/queue/application/v2/message/kafka/KafkaMessageProducerV2.java
@@ -7,4 +7,8 @@ public interface KafkaMessageProducerV2 {
     void publishQueueAlarmEvent(Long reservationId);
 
     void publishReservationAndQueueEvent(CreateReservationMessageDTOV2 event);
+
+    void publishQueueCreateFailEvent(Long reservationId);
+
+    void publishQueueDeleteFailEvent(Long reservationId);
 }

--- a/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
+++ b/src/main/java/com/qring/queue/application/v2/service/QueueServiceV2.java
@@ -16,10 +16,9 @@ public class QueueServiceV2 {
 
     private final RedisMessagePublisherV2 redisMessagePublisherV2;
 
-    // 대기열 등록
+    // NOTE: 대기열 등록
     public void enrollWaitingListByEvent(CreateReservationMessageDTOV2 event) {
 
-        // Redis에 예약 정보 저장
         redisMessagePublisherV2.addWaitingListByRestaurantIdAndReservationId(
                 event.getReservation().getRestaurant().getId(),
                 event.getReservation().getId());
@@ -29,20 +28,20 @@ public class QueueServiceV2 {
                 event.getReservation().getId());
     }
 
-    // 사용자 대기 순서 반환
+    // NOTE: 사용자 대기 순서 반환
     public QueueGetResDTOV2 getBy(Long restaurantId, Long reservationId) {
 
         return redisMessagePublisherV2.getQueueInfoByRestaurantIdAndReservationId(restaurantId, reservationId);
     }
 
-    // 대기열에서 제거
+    // NOTE: 대기열에서 제거
     public void deleteBy(Long restaurantId, Long reservationId) {
 
         redisMessagePublisherV2.removeQueueByRestaurantIdAndReservationId(restaurantId, reservationId);
     }
 
     // ============== 대기 순번 알림 발송 관련 ================
-    // 식당별 대기열 리스트 조회
+    // NOTE: 식당별 대기열 리스트 조회
     public List<Long> getWaitingListByRestaurantId(Long restaurantId) {
         String key = "waiting_list" + restaurantId; // Redis Key 생성
         Set<Object> waitingList = redisMessagePublisherV2.getFromWaitingListByKey(key); // Redis에서 모든 데이터 조회

--- a/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
@@ -54,7 +54,7 @@ public class KafkaMessageConsumerV2 {
             kafkaMessageProducerV2.publishReservationAndQueueEvent(parsedMessage);
 
             long endTime = System.currentTimeMillis();
-            log.info("Message processed in {} ms", endTime - startTime);
+            log.info("메세지 처리 속도 : {} ms", endTime - startTime);
         } catch (Exception e) {
 
             log.error("대기열 생성 실패 : {}", message, e);

--- a/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
@@ -43,7 +43,7 @@ public class KafkaMessageConsumerV2 {
 
             CreateReservationMessageDTOV2.Queue queue = CreateReservationMessageDTOV2.Queue.from(dto.getSequence());
 
-            // NOTE : 새로운 대기 정보를 포함한 DTO 생성
+            // NOTE: 새로운 대기 정보를 포함한 DTO 생성
             parsedMessage = new CreateReservationMessageDTOV2(
                     parsedMessage.getUser(),
                     parsedMessage.getReservation(),

--- a/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageConsumerV2.java
@@ -22,17 +22,18 @@ public class KafkaMessageConsumerV2 {
     private final KafkaMessageProducerV2 kafkaMessageProducerV2;
     private final ObjectMapper objectMapper;
 
-    /**
-     * 예약 생성 이벤트 소비
-     * @param message
-     */
+    // NOTE: 예약 생성 이벤트 소비
     @KafkaListener(topics = "${spring.kafka.topic.reservation-create-event}", groupId = "${spring.kafka.consumer.group-id}")
     public void extractReservationInfoBy(String message) {
         long startTime = System.currentTimeMillis();
+        Long reservationId = 0L;
 
         try {
             CreateReservationMessageDTOV2 parsedMessage = objectMapper.readValue(message, CreateReservationMessageDTOV2.class);
 
+            reservationId = parsedMessage.getReservation().getId();
+
+            // NOTE: 대기열에 등록
             queueServiceV2.enrollWaitingListByEvent(parsedMessage);
 
             QueueGetResDTOV2.QueueInfo dto = queueServiceV2.getBy(
@@ -42,42 +43,47 @@ public class KafkaMessageConsumerV2 {
 
             CreateReservationMessageDTOV2.Queue queue = CreateReservationMessageDTOV2.Queue.from(dto.getSequence());
 
-            log.info("restaurantId : {}", parsedMessage.getReservation().getRestaurant().getId());
-
-            // 새로운 대기 정보를 포함한 DTO 생성
+            // NOTE : 새로운 대기 정보를 포함한 DTO 생성
             parsedMessage = new CreateReservationMessageDTOV2(
                     parsedMessage.getUser(),
                     parsedMessage.getReservation(),
-                    queue // 새로운 Queue 정보 설정
+                    queue
             );
 
-            // 메시지 서비스로 전송
+            // NOTE: 메시지 서비스로 전송
             kafkaMessageProducerV2.publishReservationAndQueueEvent(parsedMessage);
 
             long endTime = System.currentTimeMillis();
             log.info("Message processed in {} ms", endTime - startTime);
         } catch (Exception e) {
-            log.error("메시지 추출 실패 : {}", message, e);
-            throw new QueueException(ErrorCode.BAD_REQUEST_ERROR, "메세지 추출에 실패하였습니다.");
+
+            log.error("대기열 생성 실패 : {}", message, e);
+
+            kafkaMessageProducerV2.publishQueueCreateFailEvent(reservationId);
+
+            throw new QueueException(ErrorCode.BAD_REQUEST_ERROR, "대기열 생성에 실패하였습니다.");
         }
     }
 
-    /**
-     * 예약 입장 or 취소 이벤트 소비
-     * @param message
-     */
+    // NOTE: 예약 입장 or 취소 이벤트 소비
     @KafkaListener(topics = "${spring.kafka.topic.reservation-update-event}", groupId = "${spring.kafka.consumer.group-id}")
     public void handleReservationCancellation(String message) {
+        Long reservationId = 0L;
         try {
-            // 메시지에서 예약 ID와 식당 ID 추출
+            // NOTE: 메시지에서 예약 ID와 식당 ID 추출
             UpdateReservationMessageDTOV2 event = parseMessage(message);
+            reservationId = event.getReservation().getId();
             queueServiceV2.deleteBy(event.getReservation().getRestaurant().getId(), event.getReservation().getId());
         } catch (Exception e) {
             log.error("메시지 추출 실패 : {}", message, e);
+
+            kafkaMessageProducerV2.publishQueueDeleteFailEvent(reservationId);
+
+            throw new QueueException(ErrorCode.BAD_REQUEST_ERROR, "대기열 삭제에 실패하였습니다.");
         }
     }
 
-    // 예약, 식당 아이디 추출
+    // NOTE: 예약, 식당 아이디 추출
     private UpdateReservationMessageDTOV2 parseMessage(String message) {
         try {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageProducerImplV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/kafka/KafkaMessageProducerImplV2.java
@@ -18,6 +18,12 @@ public class KafkaMessageProducerImplV2 implements KafkaMessageProducerV2 {
     @Value("${spring.kafka.topic.queue-reservation-event}")
     private String queueReservationEvent;
 
+    @Value("${spring.kafka.topic.queue-create-fail-event}")
+    private String queueCreateFailEvent;
+
+    @Value("${spring.kafka.topic.queue-delete-fail-event}")
+    private String queueDeleteFailEvent;
+
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     public void publishQueueAlarmEvent(Long reservationId) {
@@ -29,5 +35,15 @@ public class KafkaMessageProducerImplV2 implements KafkaMessageProducerV2 {
     public void publishReservationAndQueueEvent(CreateReservationMessageDTOV2 event) {
 
         kafkaTemplate.send(queueReservationEvent, event);
+    }
+
+    public void publishQueueCreateFailEvent(Long reservationId) {
+
+        kafkaTemplate.send(queueCreateFailEvent, reservationId);
+    }
+
+    public void publishQueueDeleteFailEvent(Long reservationId) {
+
+        kafkaTemplate.send(queueDeleteFailEvent, reservationId);
     }
 }

--- a/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
+++ b/src/main/java/com/qring/queue/infrastructure/messaging/redis/RedisMessagePublisherImplV2.java
@@ -22,27 +22,26 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
 
     private static final String WAITING_LIST_KEY_PREFIX = "waiting_list";
 
-    // 대기열에 등록
+    // NOTE: 대기열에 등록
     public void addWaitingListByRestaurantIdAndReservationId(Long restaurantId, Long reservationId) {
         ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
 
-        // 식당 Id 에 해당하는 Key 생성
+        // NOTE: 식당 Id 에 해당하는 Key 생성
         String key = WAITING_LIST_KEY_PREFIX + restaurantId;
 
         long score = System.currentTimeMillis();
         zSetOps.add(key, String.valueOf(reservationId), score);
     }
 
-    // 사용자 대기 순서와 총 대기 인원 반환
+    // NOTE: 사용자 대기 순서와 총 대기 인원 반환
     public QueueGetResDTOV2 getQueueInfoByRestaurantIdAndReservationId(Long restaurantId, Long reservationId) {
         ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
 
-        // 식당 Id 에 해당하는 Key 생성
         String key = WAITING_LIST_KEY_PREFIX + restaurantId;
 
         log.info("Redis 조회 시도: restaurantId={}, reservationId={}", restaurantId, reservationId);
 
-        // 사용자 대기 순서 조회
+        // NOTE: 사용자 대기 순서 조회
         int rank = Optional.ofNullable(zSetOps.rank(key, String.valueOf(reservationId)))
                 .map(Long::intValue)
                 .orElseThrow(() -> new QueueException(ErrorCode.NOT_FOUND_ERROR, "대기열에 존재하지 않거나 이미 삭제되었습니다."));
@@ -60,18 +59,11 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
                 rank);
 
 
-        // 대기 순서는 Redis의 rank가 0부터 시작하므로 1을 더해 반환
+        // NOTE: 대기 순서는 Redis의 rank가 0부터 시작하므로 1을 더해 반환
         return QueueGetResDTOV2.of(queueInfo);
     }
 
-    // 사용자 순서 조회 반환
-    private int getRankByKeyAndValue(ZSetOperations<String, Object> zSetOps, String key, String value) {
-        return Optional.ofNullable(zSetOps.rank(key, value))
-                .map(Long::intValue)
-                .orElse(-1);
-    }
-
-    // 대기열에서 제거
+    // NOTE: 대기열에서 제거
     public void removeQueueByRestaurantIdAndReservationId(Long restaurantId, Long reservationId) {
         ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
 
@@ -81,7 +73,7 @@ public class RedisMessagePublisherImplV2 implements RedisMessagePublisherV2 {
     }
 
     // ============ 대기 순번 알림 발송 관련 ================
-    // 대기열 정보 전체 가져오기
+    // NOTE: 대기열 정보 전체 가져오기
     public Set<Object> getFromWaitingListByKey(String key) {
         ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
         return zSetOps.range(key, 0, -1); // ZSet의 모든 데이터를 가져옴

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,6 +42,8 @@ spring:
       reservation-create-event: reservation-create-event-topic
       reservation-update-event: reservation-update-event-topic
       queue-reservation-event: queue-reservation-event-topic
+      queue-create-fail-event: queue-create-fail-event-topic
+      queue-delete-fail-event: queue-delete-fail-event-topic
 
   config:
     import: classpath:application-key.yml


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #26 

## 📝 Description

- 대기 생성 및 삭제 실패시 예약 서비스로 FailEvent가 발행되도록 구현하였습니다.
- 추가적으로 error와 주석 커스텀 작업도 진행하였습니다.
<br/>

> 대기 생성 실패

<img width="778" alt="스크린샷 2025-01-17 22 57 56" src="https://github.com/user-attachments/assets/9687b732-6b94-4b32-8747-ad896583241d" />
<br/><br/>

> 대기 삭제 실패

<img width="968" alt="스크린샷 2025-01-17 22 59 17" src="https://github.com/user-attachments/assets/b21499db-58a3-4618-9e75-9028dd530e57" />

## 💬 To Reivewers

